### PR TITLE
Use Apikey header in documentation examples

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -83,9 +83,11 @@ You can copy your api-base-url from the homepage of the instance.
 
 OK! We're going to create a new [Organization](http://popoloproject.com/specs/organization.html) record. When you specify your email address to cURL with the `--user` option it will prompt you for your password.
 
-In this example our API token is **2a0abbefe6aefb67ba5302a12570c2af2a7f4433** and our instance is called **walkthrough**.
+In this example our API key is **2a0abbefe6aefb67ba5302a12570c2af2a7f4433** and our instance is called **walkthrough**.
 
-    $ curl  --header 'Content-Type: application/json' --data '{"apikey": "2a0abbefe6aefb67ba5302a12570c2af2a7f4433", "name": "Widgets Inc"}' http://walkthrough.popit.mysociety.org/api/v0.1/organizations
+Your API key needs to be given in the `Apikey` header.
+
+    $ curl --header 'Apikey: 2a0abbefe6aefb67ba5302a12570c2af2a7f4433'  --header 'Content-Type: application/json' --data '{"name": "Widgets Inc"}' http://walkthrough.popit.mysociety.org/api/v0.1/organizations
 
     {
       "result": {
@@ -101,6 +103,10 @@ In this example our API token is **2a0abbefe6aefb67ba5302a12570c2af2a7f4433** an
         "other_names": []
       }
     }
+
+Alternatively you can add an `apikey` property to the JSON body and provide your API key there.
+
+    $ curl --header 'Content-Type: application/json' --data '{"apikey": "2a0abbefe6aefb67ba5302a12570c2af2a7f4433", "name": "Widgets Inc"}' http://walkthrough.popit.mysociety.org/api/v0.1/organizations
 
 Congratulations! You've now created a new Organization record using the API. You can access this record at the `url` property of the record.
 

--- a/docs/api/writing.md
+++ b/docs/api/writing.md
@@ -48,12 +48,12 @@ This is an example of sending a request using [cURL](http://curl.haxx.se/) (a co
 
 {% highlight bash %}
 
-$ curl                                                 \
-    --request POST                                     \
-    --header "Accept: application/json"                \
-    --header "Content-Type: application/json"          \
-    --data '{ "apikey": "2a0abbefe6aefb67ba5302a12570c2af2a7f4433", \
-    "name": "Joe Bloggs" }' \
+$ curl                                                          \
+    --request POST                                              \
+    --header "Apikey: 2a0abbefe6aefb67ba5302a12570c2af2a7f4433" \
+    --header "Accept: application/json"                         \
+    --header "Content-Type: application/json"                   \
+    --data '{ "name": "Joe Bloggs" }'                           \
     http://test.popit.mysociety.org/api/v0.1/persons
 
 {
@@ -80,9 +80,10 @@ Sending a `DELETE` request to a document url will cause that document to be
 deleted. An empty 204 response will be returned.
 
 {% highlight bash %}
-$ curl                                     \
-    -X DELETE                              \
-    http://test.127.0.0.1.xip.io:3000/api/v0.1/persons/50d1f2e1c03858f9f6000006?apikey=2a0abbefe6aefb67ba5302a12570c2af2a7f4433
+$ curl                                                          \
+    --request DELETE                                            \
+    --header 'Apikey: 2a0abbefe6aefb67ba5302a12570c2af2a7f4433' \
+    http://test.127.0.0.1.xip.io:3000/api/v0.1/persons/50d1f2e1c03858f9f6000006'
 
 {}
 {% endhighlight %}


### PR DESCRIPTION
Recommend using a header to supply the API key. I've still documented the putting it in the body method, in case that's useful to people.

Part of https://github.com/mysociety/popit/issues/624
