### PR TITLE
Api documentation updates

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -6,11 +6,15 @@
         <li><a href="{{ site.baseurl }}/docs/"><h2>Documentation</h2></a></li>
         <li><a href="{{ site.baseurl }}/docs/getting-started/">Getting started</a></li>
         <li><a href="{{ site.baseurl }}/docs/adding-data/">Adding data</a></li>
+        <li><a href="{{ site.baseurl }}/docs/api/"><h2>API</h2></a></li>
         <li><a href="{{ site.baseurl }}/docs/api/">Using the API</a></li>
         <li><a href="{{ site.baseurl }}/docs/api/reference/">API Reference</a></li>
         <li><a href="{{ site.baseurl }}/docs/api/writing/">Writing to the API</a></li>
         <li><a href="{{ site.baseurl }}/docs/api/images/">Images and the API</a></li>
-        <li><a href="{{ site.baseurl }}/docs/api/search/">Search</a></li>
-        <li><a href="{{ site.baseurl }}/docs/install/">Install</a></li>
+        <li><a href="{{ site.baseurl }}/docs/api/search/">Search API</a></li>
+        <li><a href="{{ site.baseurl }}/docs/api/merging/">Merging API</a></li>
+        <li><a href="{{ site.baseurl }}/docs/install/"><h2>Install</h2></a></li>
+        <li><a href="{{ site.baseurl }}/docs/install/">Installing locally</a></li>
+        <li><a href="{{ site.baseurl }}/docs/install/vagrant/">Installing using Vagrant</a></li>
     </ul>
 </nav>

--- a/docs/api/merging.md
+++ b/docs/api/merging.md
@@ -1,0 +1,114 @@
+---
+layout: docs
+title: Merging records
+description: How to merge people using the PopIt API
+---
+
+**Note**: Currently it's only possible to merge people using the API. If there is enough interest then we may extend this to other record types in the future.
+
+## Merge one person into another
+
+Merges one person records into another person record, updating the **primary** person and removing the **secondary** person.
+
+If the two records have different `name` properties then the **secondary** record's name is added to the **primary** person's `other_names` array. If the two records have other non-array fields which are different then an error will be returned explaining the problem. All array fields will be merged together after removing duplicates.
+
+    POST /api/v0.1/persons/:primary_id/merge/:secondary_id
+
+### Example
+
+The example responses below use this **primary** person record:
+
+{% highlight json %}
+{
+  "id": "david-cameron",
+  "name": "David Cameron",
+  "links": [
+    {
+      "url": "http://en.wikipedia.org/wiki/David_Cameron",
+      "note": "Wikipedia page"
+    }
+  ],
+  "contact_details": [
+    {
+      "label": "Twitter Account",
+      "type": "twitter",
+      "value": "david_cameron"
+    }
+  ]
+}
+
+{% endhighlight %}
+
+and this **secondary** person record:
+
+{% highlight json %}
+{
+  "id": "david-cameron-2",
+  "name": "David Cameron",
+  "links": [
+    {
+      "url": "https://www.conservatives.com/OurTeam/David_Cameron.aspx",
+      "note": "Conservative Party page"
+    }
+  ],
+  "contact_details": [
+    {
+      "label": "Facebook Account",
+      "type": "facebook",
+      "value": "DavidCameronOfficial"
+    }
+  ]
+}
+{% endhighlight %}
+
+#### Success response
+
+    POST /api/v0.1/persons/david-cameron/merge/david-cameron-2
+
+{% highlight json %}
+{
+  "result": {
+    "id": "david-cameron",
+    "name": "David Cameron",
+    "links": [
+      {
+        "url": "http://en.wikipedia.org/wiki/David_Cameron",
+        "note": "Wikipedia page"
+      },
+      {
+        "url": "https://www.conservatives.com/OurTeam/David_Cameron.aspx",
+        "note": "Conservative Party page"
+      }
+    ],
+    "contact_details": [
+      {
+        "label": "Twitter Account",
+        "type": "twitter",
+        "value": "david_cameron"
+      },
+      {
+        "label": "Facebook Account",
+        "type": "facebook",
+        "value": "DavidCameronOfficial"
+      }
+    ]
+  }
+}
+{% endhighlight %}
+
+**Note**: Some fields have been omitted for brevity.
+
+#### Error response
+
+If the documents have non-array properties that differ, for instance if `david-cameron` had `{"gender": "male"}` and `david-cameron-2` had `{"gender": "m"}` then you would get an error like the following. Note that this doesn't apply to array properties, which will be merged together.
+
+    POST /api/v0.1/persons/david-cameron/merge/david-cameron-2
+
+{% highlight json %}
+{
+  "errors": [
+    "Unresolvable merge conflict",
+    "Please resolve conflict with gender: male doesn't match m"
+  ]
+}
+{% endhighlight %}

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -123,6 +123,30 @@ An object is determined to be a translation object if all of the keys are valid 
 
 When indexing multiple languages each translation is stored in a separate string key. So for the example above the English and Russian translations would be stored in `name_en` and `name_ru` respectively. So to search for a name in Russian you can use a query like `name_ru:Джон`. The `name` key will still exist, but will only contain the default language.
 
+## Embedding memberships
+
+When retrieving a person, organization or post from the API you can include the record's memberships by using the `?embed` parameter.
+
+### Skip embed
+
+By default an objects memberships are included in API responses, you can suppress this by setting the embed parameter to a blank string:
+
+    https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/1?embed=
+
+### Embed related people/organizations
+
+If you want to include all the related organizations for memberships then you can set the `?embed=membership.organization`. Similarly if you want to include the person in each membership then you can set `?embed=membership.person`.
+
+    https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/1?embed=membership.organization
+
+### Multi-level embeds
+
+Embedding can be nested up to three levels deep, so you can embed memberships with the related people and their memberships with the related organizations and their memberships with their related people. Note though that queries like this can be very slow, especially on collection endpoints.
+
+    https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/1?embed=membership.person.membership.organization.membership.person
+
+This works on collections of records, individual records and search results.
+
 ## Examples
 
 To view a list of all the people (**persons**) in the database:
@@ -409,7 +433,7 @@ Multiple levels of embedding can be specified:
 
 https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/104?embed=membership.organization.membership.person
 
-Only three levels of embeding are permitted.
+Only three levels of embedding are permitted.
 
 If an organization has both person and organization memberships then it's only possible to join one at a time presently.
 

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@ description: The PopIt API allows you to easily access all the data stored in Po
 ## Introduction
 {:.no_toc}
 
-The PopIt API offers a JSON interface for accessing and manipulating People, Organizations, Memberships and Posts that are stored in an instance. Every PopIt instance has an API that makes almost all the data stored in it accessible programatically. You can access the API by visiting `/api/v0.1` in your instance, e.g. [https://za-peoples-assembly.popit.mysociety.org/api/v0.1/](https://za-peoples-assembly.popit.mysociety.org/api/v0.1/).
+The PopIt API offers a JSON interface for accessing and manipulating People, Organizations, Memberships and Posts that are stored in an instance. Every PopIt instance has an API that makes almost all the data stored in it accessible programatically. You can access the API by visiting `/api/v0.1` in your instance, e.g. <https://za-peoples-assembly.popit.mysociety.org/api/v0.1/>.
 
 ### Contents
 {:.no_toc}
@@ -27,10 +27,10 @@ All textual entries stored in PopIt follow the [Popolo](http://popoloproject.com
 
 The API allows you to query four types of collection, **persons**, **organizations**, **memberships** and **posts**. Anywhere in the documentation you see `:collection` you can replace it with one of those four types.
 
-- https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons
-- https://za-peoples-assembly.popit.mysociety.org/api/v0.1/organizations
-- https://za-peoples-assembly.popit.mysociety.org/api/v0.1/memberships
-- https://za-peoples-assembly.popit.mysociety.org/api/v0.1/posts
+- <https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons>
+- <https://za-peoples-assembly.popit.mysociety.org/api/v0.1/organizations>
+- <https://za-peoples-assembly.popit.mysociety.org/api/v0.1/memberships>
+- <https://za-peoples-assembly.popit.mysociety.org/api/v0.1/posts>
 
 **Note**: the South Africa People's Assembly instance doesn't currently use the **posts** collection.
 
@@ -131,19 +131,19 @@ When retrieving a person, organization or post from the API you can include the 
 
 By default an objects memberships are included in API responses, you can suppress this by setting the embed parameter to a blank string:
 
-    https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/1?embed=
+<https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/1?embed=>
 
 ### Embed related people/organizations
 
 If you want to include all the related organizations for memberships then you can set the `?embed=membership.organization`. Similarly if you want to include the person in each membership then you can set `?embed=membership.person`.
 
-    https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/1?embed=membership.organization
+<https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/1?embed=membership.organization>
 
 ### Multi-level embeds
 
 Embedding can be nested up to three levels deep, so you can embed memberships with the related people and their memberships with the related organizations and their memberships with their related people. Note though that queries like this can be very slow, especially on collection endpoints.
 
-    https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/1?embed=membership.person.membership.organization.membership.person
+<https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/1?embed=membership.person.membership.organization.membership.person>
 
 This works on collections of records, individual records and search results.
 
@@ -151,7 +151,7 @@ This works on collections of records, individual records and search results.
 
 To view a list of all the people (**persons**) in the database:
 
-https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons
+<https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons>
 
 {% highlight json %}
 {
@@ -273,7 +273,7 @@ https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons
 
 Or view the record for an individual person in the database:
 
-https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/104
+<https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/104>
 
 {% highlight json %}
 {
@@ -355,7 +355,7 @@ https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.z
 
 You can expand the contents of the memberships and inline persons or organizations using the embed query parameter.
 
-https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/104?embed=membership.organization
+<https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/104?embed=membership.organization>
 
 {% highlight json %}
 {
@@ -431,7 +431,7 @@ https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.z
 
 Multiple levels of embedding can be specified:
 
-https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/104?embed=membership.organization.membership.person
+<https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.za/person/104?embed=membership.organization.membership.person>
 
 Only three levels of embedding are permitted.
 

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -4,7 +4,16 @@ title: API Reference
 description: The PopIt API allows you to easily access all the data stored in PopIt from your code or other websites.
 ---
 
+## Introduction
+{:.no_toc}
+
 The PopIt API offers a JSON interface for accessing and manipulating People, Organizations, Memberships and Posts that are stored in an instance. Every PopIt instance has an API that makes almost all the data stored in it accessible programatically. You can access the API by visiting `/api/v0.1` in your instance, e.g. [https://za-peoples-assembly.popit.mysociety.org/api/v0.1/](https://za-peoples-assembly.popit.mysociety.org/api/v0.1/).
+
+### Contents
+{:.no_toc}
+
+* This will be replaced with the ToC, excluding the "Introduction" and "Contents" headers above
+{:toc}
 
 ## Versioning
 
@@ -114,7 +123,7 @@ An object is determined to be a translation object if all of the keys are valid 
 
 When indexing multiple languages each translation is stored in a separate string key. So for the example above the English and Russian translations would be stored in `name_en` and `name_ru` respectively. So to search for a name in Russian you can use a query like `name_ru:Джон`. The `name` key will still exist, but will only contain the default language.
 
-### Popolo extensions
+## Popolo extensions
 
 In addition to the [Popolo schemas](http://popoloproject.com/specs/) we have added some PopIt specific customisations.
 

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -123,42 +123,6 @@ An object is determined to be a translation object if all of the keys are valid 
 
 When indexing multiple languages each translation is stored in a separate string key. So for the example above the English and Russian translations would be stored in `name_en` and `name_ru` respectively. So to search for a name in Russian you can use a query like `name_ru:Джон`. The `name` key will still exist, but will only contain the default language.
 
-## Popolo extensions
-
-In addition to the [Popolo schemas](http://popoloproject.com/specs/) we have added some PopIt specific customisations.
-
-#### Organization memberships
-
-Popolo currently only allows the members of an Organization to be Persons, but we've extended this to allow them to also be other Organizations. This allows you to e.g. model coalitions. The party Organizations which are part of the coalition have Memberships connecting them to the coalition Organization.
-
-An example Membership modelling The Conservative Party's Membership in the UK's Cameron Ministry coalition might look something like:
-
-{% highlight json %}
-{
-  "organization_id": "cameron_ministry",
-  "member": {
-    "@type": "Organization",
-    "id": "conservative_party"
-  }
-}
-{% endhighlight %}
-
-Then the Liberal Democrats' Membership would look something like:
-
-{% highlight json %}
-{
-  "organization_id": "cameron_ministry",
-  "member": {
-    "@type": "Organization",
-    "id": "liberal_democrats"
-  }
-}
-{% endhighlight %}
-
-Where `cameron_ministry` is the id of the coalition Organization and `conservative_party` and `liberal_democrats` are the ids of the parties in the coalition.
-
-When the API returns the `conservative_party` or `liberal_democrats` record, the `memberships` array property will include the Membership to the coalition. Likewise when the API returns the `cameron_ministry` record the `memberships` array property will include the Memberships to the two parties' Organizations.
-
 ## Examples
 
 To view a list of all the people (**persons**) in the database:

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -410,7 +410,7 @@ https://za-peoples-assembly.popit.mysociety.org/api/v0.1/persons/org.mysociety.z
         "role": "Speaker",
         "person_id": "org.mysociety.za/person/104",
         "organization_id": {
-          "id: "org.mysociety.za/house/national-assembly",
+          "id": "org.mysociety.za/house/national-assembly",
           "slug": "national-assembly",
           "classification": "house",
           "name": "National Assembly",


### PR DESCRIPTION
- Updates documentation for `?embed` parameter
- Adds documentation for the person merging API endpoint
- Adds a Table of Contents to the API Reference page
- Turns all urls on API Reference page into links
- Removes old documentation about Popolo extensions that are now part of Popolo
- Couple of other minor fixes
