### PR TITLE
Fix documentation of date range searching

### DIFF
--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -47,7 +47,7 @@ This will only match the exact string specified.
 
 You can match date ranges using the API, e.g. to find all memberships which started in 2013:
 
-    /api/v0.1/search/memberships?q=start_date:[2013/01/01+TO+2013/12/31]
+    /api/v0.1/search/memberships?q=start_date:[2013-01-01+TO+2013-12-31]
 
 #### Searching Dates
 


### PR DESCRIPTION
Ranges are formed as [2013-01-01+TO+2013-12-31] not [2013/01/01+TO+2013/12/31]

Closes https://github.com/mysociety/popit/issues/452
