### PR TITLE
Remove all references to migration tool

### DIFF
--- a/about/data-freedom.html
+++ b/about/data-freedom.html
@@ -8,21 +8,6 @@ title: Data Import
   also let you upload existing data to quickly populate a new site.
 </p>
 
-
-<h2>Migration Tool</h2>
-
-<p>
-  If you have been collecting information on people in a spreadsheet, this
-  web based tool will let you quickly upload it all into PopIt rather than
-  entering it manually.
-</p>
-
-<p>
-  To use it, simply go to <code>/migration</code> in your PopIt instance and
-  follow the instructions.
-</p>
-
-
 <h2>API</h2>
 
 <p>

--- a/docs/adding-data.md
+++ b/docs/adding-data.md
@@ -3,13 +3,7 @@ layout: docs
 title: Adding data
 ---
 
-As well as entering data through the UI, PopIt will let you enter and access data easily from your code. It will also let you upload existing data to quickly populate a new site.
-
-## Migration Tool
-
-If you have been collecting information on people in a spreadsheet, this web based tool will let you quickly upload it all into PopIt rather than entering it manually.
-
-To use it, simply go to <code>/migration</code> in your PopIt instance and follow the instructions.
+As well as entering data through the UI, PopIt will let you enter and access data easily from your code.
 
 ## API
 


### PR DESCRIPTION
Now that Every Politician exists we not longer need to link to the migration tool. In a future pull request we need to add back in some links to Every Politician.
